### PR TITLE
Checking only value of content-length header.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,8 @@ module.exports = function (opts) {
 
   return function *(next) {
     var encoding = 'transfer-encoding' in this.req.headers;
-    var length = 'content-length' in this.req.headers &&
-      this.req.headers['content-length'] != 0;
 
-    if ((encoding || length) && !this.req._readableState.ended) {
+    if ((encoding || this.request.length) && !this.req._readableState.ended) {
       try {
         this.request.body = yield parse(this.request, opts);
       } catch (err) {


### PR DESCRIPTION
In my case this.req.headers['content-length'] is a string '0' and '0' !== 0 is false and it leads to wrong behavior.
