### PR TITLE
remove _readableState.ended

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function (opts) {
   return function *(next) {
     var encoding = 'transfer-encoding' in this.req.headers;
 
-    if ((encoding || this.request.length) && !this.req._readableState.ended) {
+    if (encoding || this.request.length) {
       try {
         this.request.body = yield parse(this, opts);
       } catch (err) {

--- a/index.js
+++ b/index.js
@@ -14,21 +14,21 @@ var parse = require('co-body');
  */
 
 module.exports = function (opts) {
+
   var opts = opts || {};
   var empty = opts.empty === undefined || opts.empty;
-
   return function *(next) {
-    var encoding = 'transfer-encoding' in this.req.headers;
-
-    if (encoding || this.request.length) {
-      try {
-        this.request.body = yield parse(this, opts);
-      } catch (err) {
-        if (err.status !== 415 || !empty)
-          throw err;
+    if (!this.request.body) {
+      var encoding = 'transfer-encoding' in this.req.headers;
+      if (encoding || this.request.length || (!empty && this.request.method != 'GET')) {
+        try {
+          this.request.body = yield parse(this, opts);
+        } catch (err) {
+          if (err.status !== 415 || !empty)
+            throw err;
+        }
       }
     }
-
     yield next;
   }
 };


### PR DESCRIPTION
The requirement of `!this.req._readableState.ended` prevents some legitimate request's bodies from being parsed properly. Also fixes some test that were failing because of the !empty condition.
